### PR TITLE
Fix CI reliability for coverage and R CMD checks

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -6,15 +6,15 @@ name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -32,9 +32,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("remotes"))
+          install.packages(c("remotes"), repos = "https://cloud.r-project.org")
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
+          if (!requireNamespace("covr", quietly = TRUE)) {
+            stop("covr package failed to install")
+          }
         shell: Rscript {0}
 
       - name: Test coverage

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,11 @@ Package: memofunc
 Type: Package
 Title: Function Memoization
 Version: 1.0.3
-Author: Roy Wetherall <rwetherall@gmail.com>
-Maintainer: Roy Wetherall <rwetherall@gmail.com>
+Authors@R:
+    person(given = "Roy",
+           family = "Wetherall",
+           role = c("aut", "cre"),
+           email = "rwetherall@gmail.com")
 Description: A simple way to memoize function results to improve performance by eliminating unnecessary computation or data retrieval activities.
 Depends: R (>= 3.5.0)
 License: GPL-3 

--- a/man/memo.Rd
+++ b/man/memo.Rd
@@ -63,7 +63,11 @@ simple.function2 <- (function (value) value) \%>\% memo()
 anonymous.memo <- memo(function (value) value, id = "example/anon")
 
 # use an explicit id to keep cache stable across renames or wrappers
-renamed.function <- simple.function
+# start from the original non-memoized function to avoid wrapping a memo twice
+renamed.function <- function (value) {
+  print("Executing!")
+  value
+}
 renamed.memo <- memo(renamed.function, id = "simple.function")
 
 # the first time we call the memo the function will execute


### PR DESCRIPTION
## Summary
- update the test-coverage workflow to use current GitHub Actions versions and `ubuntu-latest` runners
- harden coverage dependency setup by explicitly checking that `covr` installed before running `covr::codecov()`
- resolve R CMD check issues by adding `Authors@R` metadata and fixing the memo documentation example that re-memoized an already memoized function

## Validation
- local `R CMD check --as-cran` now completes with no errors and no warnings (one non-fatal URL NOTE)
- CI runs on this branch are now starting and progressing on current runner images